### PR TITLE
JetBrains License Server 30803

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG JLS_VERSION=30333
-ARG JLS_SHA256=2bb37709c174cb1005515a356644e2250bd326d4b2777409ac3b39802a56334e
+ARG JLS_VERSION=30803
+ARG JLS_SHA256=a9a2b6163354382162e4e9802ca88a651ca2421a2f495a558babafe5f02f063a
 
 FROM crazymax/yasu:latest AS yasu
 FROM alpine:3.15
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache \
     bash \
     ca-certificates \
     curl \
-    openjdk8-jre \
+    openjdk11-jre \
     openssl \
     shadow \
     zip \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -25,8 +25,6 @@ target "image-all" {
   inherits = ["image"]
   platforms = [
     "linux/amd64",
-    "linux/arm/v6",
-    "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
     "linux/s390x"


### PR DESCRIPTION
> ### **[Build #30803﻿](https://www.jetbrains.com/help/license_server/release_notes.html#30803)**
>
> **Released on**: February 4, 2022
>
> * Minimum JDK/JRE version supported by the FLS is 11. Please [update](https://www.jetbrains.com/help/license_server/troubleshooting_start_stop.html#failed-to-start) it before the FLS update.
> * Updated a log4j2 version 2.17.1 with security fix for [CVE-2021-44832](https://nvd.nist.gov/vuln/detail/CVE-2021-44832).
> * log4j 1.12 is replaced with [reload4j](https://reload4j.qos.ch/) in JetLauncher
> * Explicit "Logout" action is added to Floating License Server Dashboard






